### PR TITLE
Add git setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ run `hugo server`, then connect to http://localhost:1313/
 
 ## Live Site
 https://ebmorran.github.io
+
+## Git Setup
+After cloning, set the remote URL and fetch the theme submodule:
+
+```bash
+git remote add origin https://github.com/ebmorran/ebmorran.github.io.git
+# Initialize the theme submodule
+git submodule update --init --recursive
+```


### PR DESCRIPTION
## Summary
- document how to set a remote for the repo
- mention how to fetch the hugo theme submodule

## Testing
- `git remote -v`
- `git submodule status`

------
https://chatgpt.com/codex/tasks/task_e_6883153d71cc8330adae3df0dcabedec