### PR TITLE
Fix bio year count and Medavie employment history

### DIFF
--- a/ebmorran.github.io/config.yaml
+++ b/ebmorran.github.io/config.yaml
@@ -133,7 +133,7 @@ params:
     intro: ""
     title: "Elizabeth Morran"
     subtitle: "Content designer"
-    content: "I'm a content designer with six years of experience as a professional writer and two in UX. I specialize in deep-diving into subject matter knowledge to create strategic content that demystifies complexity and orients users. I'm a true grammar nerd who's obsessed with the nuts and bolts of writing, and I love using AI and automations to free up human brains for human creativity."
+    content: "I'm a content designer with seven years of experience as a professional writer and two in UX. I specialize in deep-diving into subject matter knowledge to create strategic content that demystifies complexity and orients users. I'm a true grammar nerd who's obsessed with the nuts and bolts of writing, and I love using AI and automations to free up human brains for human creativity."
     image: /images/me.jpg
     # Make title & subtitle font slightly smaller.
     bottomImage:

--- a/ebmorran.github.io/content/medavie-blue-cross/_index.md
+++ b/ebmorran.github.io/content/medavie-blue-cross/_index.md
@@ -1,5 +1,5 @@
 ---
 logo: "/images/logos/mbc-logo-en.png"
 title: "Medavie Blue Cross"
-desc: "Medavie Blue Cross is a major Canadian health insurance provider, covering the Atlantic region and other parts of the country. I've worked here for two years as a UX writer/strategist on the content design team, creating seamless and simple content experiences for our members, employees and business partners."
+desc: "Medavie Blue Cross is a major Canadian health insurance provider, covering the Atlantic region and other parts of the country. I worked there for three years as a UX writer/strategist on the content design team, creating seamless and simple content experiences for our members, employees and business partners."
 ---


### PR DESCRIPTION
## Summary
- change hero bio from "six" to "seven" years of experience
- update Medavie Blue Cross description to reflect three years at the company

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688318856df0833094cfd48bd3fcf9bc