### PR TITLE
Add descriptive alt text to images

### DIFF
--- a/ebmorran.github.io/content/cibc/newcomer-account.md
+++ b/ebmorran.github.io/content/cibc/newcomer-account.md
@@ -20,7 +20,7 @@ toc: true
 ## Context
 In a banking product for newcomers to Canada, we transitioned from automatic to manual identity verification in our secure portal. As the content designer assigned to this project, I worked with a UX designer to create the new upload flow for the user's ID documents.
 
-<img src="/image_samples/cibc/newcomer/user-flow.png" style="margin: auto; width: 100%; padding-bottom:10px;">
+<img src="/image_samples/cibc/newcomer/user-flow.png" alt="User flow diagram for manual ID verification" style="margin: auto; width: 100%; padding-bottom:10px;">
 
 The verification process:
 * The user uploads their documents. They can't proceed to the next step (funding the account) until manual review is complete. 
@@ -29,7 +29,7 @@ The verification process:
 * If the documents are approved, they can fund the account.
 
 ## The problem
-<img src="/image_samples/cibc/newcomer/base-screen.png" style="margin: auto; width: 50%; padding-bottom:10px;">
+<img src="/image_samples/cibc/newcomer/base-screen.png" alt="Original document upload screen with status under the upload button" style="margin: auto; width: 50%; padding-bottom:10px;">
 
 Per business requirements, the document status appeared only under the "Upload your passport..." button. The current status and next step were never clearly surfaced, forcing users to rely on visual searching and deduction.
 
@@ -45,7 +45,7 @@ I raised concerns about this approach, identifying key risks:
 To mitigate these risks and clarify the process, I proposed three contextual banner messages, with corresponding statuses under "Upload your passport and immigration document."
 
 ### After upload
-<img src="/image_samples/cibc/newcomer/message-1.png" style="margin: auto; width: 50%; padding-bottom:10px;">
+<img src="/image_samples/cibc/newcomer/message-1.png" alt="Information banner showing documents under review" style="margin: auto; width: 50%; padding-bottom:10px;">
 
 * **Information banner:** "We received your documents. You'll get an email when we're done reviewing them."
 * **Status changes:** "Upload your passport and immigration document" updates to "Under review," reinforcing the banner message. 
@@ -56,7 +56,7 @@ The user is now aware of:
 * What will happen next. 
 
 ### Documents approved
-<img src="/image_samples/cibc/newcomer/message-2.png" style="margin: auto; width: 50%; padding-bottom:10px;">
+<img src="/image_samples/cibc/newcomer/message-2.png" alt="Success banner after documents are approved" style="margin: auto; width: 50%; padding-bottom:10px;">
 
 * **Success banner:** "We verified your documents and it's time to make a one-time wire transfer to your new account. Select 'Download wire transfer instructions' to continue." 
 * **Status changes:** As in the original requirements, the "Upload your passport" status changes to "Completed on \[date\]," and the "Download wire transfer instructions" status changes to "Available." 
@@ -64,7 +64,7 @@ The user is now aware of:
 The user does not have to hunt for information: they know exactly where to look to proceed.
 
 ### Documents rejected
-<img src="/image_samples/cibc/newcomer/message-3.png" style="margin: auto; width: 50%; padding-bottom:10px;">
+<img src="/image_samples/cibc/newcomer/message-3.png" alt="Warning banner when document verification fails" style="margin: auto; width: 50%; padding-bottom:10px;">
 
 * **Warning banner:** "We couldn't verify your documents. Please upload your passport and immigration document again to continue your account setup. If we still can't verify your identity, you can show us your documents at a CIBC Banking Centre when you arrive in Canada."
 * **Status changes**: "Upload your passport" status changes to "Your documents couldn't be verified. Upload them again to continue."

--- a/ebmorran.github.io/content/freelance/justgo.md
+++ b/ebmorran.github.io/content/freelance/justgo.md
@@ -22,7 +22,7 @@ Social engagement is directly linked to wellbeing in old age, but seniors with d
 
 ## Concept
 
-<img src="/image_samples/justgo/outcomes.png" width="90%">
+<img src="/image_samples/justgo/outcomes.png" alt="Infographic showing outcomes for justGO riders" width="90%">
 
 &nbsp;
 
@@ -35,13 +35,13 @@ The goal of the app is to help seniors age in place and maintain independence by
 
 ### User flow
 
-<img src="/image_samples/justgo/user-flow.png" width="90%">
+<img src="/image_samples/justgo/user-flow.png" alt="User flow diagram for joining a justGO carpool" width="90%">
 
 &nbsp;
 
 ### Onboarding screens
 
-<img src="/image_samples/justgo/onboarding.png" width="90%">
+<img src="/image_samples/justgo/onboarding.png" alt="Onboarding screens introducing the justGO app" width="90%">
 
 &nbsp;
 
@@ -49,10 +49,10 @@ Our onboarding screens clearly explain the concept of the app and let users know
 
 ### App screens
 
-<img src="/image_samples/justgo/browse-select.png" width="90%">
+<img src="/image_samples/justgo/browse-select.png" alt="Screens for browsing and selecting rides" width="90%">
 
 &nbsp;
 
 The app makes it easy to browse nearby events. Pricing information includes the word "ride" as a reminder that only the ride is included. Information on buying tickets, if required, would be included on each event details screen.
 
-<img src="/image_samples/justgo/review-go.png" width="90%">
+<img src="/image_samples/justgo/review-go.png" alt="Review trip and go screens of the app" width="90%">

--- a/ebmorran.github.io/content/freelance/starbucks.md
+++ b/ebmorran.github.io/content/freelance/starbucks.md
@@ -16,7 +16,7 @@ This app was an assignment completed in the Interactive Media Management program
 
 The holidays are all about sharing, so my partner and I wanted our app to let users send their friends a sweet surprise. We based our concept on the "candygram" tradition, where friends and loved ones send each other messages attached to candy canes. Our secret messages would come attached to a delicious drink in a red-and-white striped cup. 
 
-<img src="/image_samples/starbucks/appflow.png" width="100%">
+<img src="/image_samples/starbucks/appflow.png" alt="App flow diagram for the Starbucks Candygram concept" width="100%">
 
 &nbsp;
 

--- a/ebmorran.github.io/content/medavie-blue-cross/delisted-providers.md
+++ b/ebmorran.github.io/content/medavie-blue-cross/delisted-providers.md
@@ -11,7 +11,7 @@ socialShare: false
 toc: false
 ---
 <div id="delisted-img-container" style="margin:auto; padding-bottom: 25px;">
-<img src="/image_samples/medavie/delisted-providers/description.png" style="margin: auto; width: 70%;">
+<img src="/image_samples/medavie/delisted-providers/description.png" alt="Screenshot describing the delisted provider filter" style="margin: auto; width: 70%;">
 </div>
 
 ## Request
@@ -42,25 +42,25 @@ While the designer suggested displaying labels on both active and delisted provi
 
 ### Display
 
-<img src="/image_samples/medavie/delisted-providers/brainstorming.jpg" style="margin: auto; width: 100%; padding-bottom:10px;">
+<img src="/image_samples/medavie/delisted-providers/brainstorming.jpg" alt="Whiteboard brainstorming options for delisted provider label" style="margin: auto; width: 100%; padding-bottom:10px;">
 
 When it came to displaying these providers in search, I identified three possible scenarios:
 1. Search does not return delisted providers
 2. Search returns both delisted and active providers
 3. Search only returns delisted providers.
 
-<img src="/image_samples/medavie/delisted-providers/draft-options.jpg" style="margin: auto; width: 100%; padding-bottom:10px;">
+<img src="/image_samples/medavie/delisted-providers/draft-options.jpg" alt="Draft options for delisted provider search filter" style="margin: auto; width: 100%; padding-bottom:10px;">
 
 Because delisted providers can't be claimed, we wanted to make sure that users were exposed to the explanation of "delisted provider" before they could toggle them on or off in the search results. Initially, the designer created an alert message that would appear in scenario 2, whenever a search contained delisted providers. My concern with an alert was that it could be intrusive, since most users don't want to see delisted providers. I suggested displaying a filter where both the description of "delisted provider" and the toggle button were collapsed by default, so that they would be exposed at the same time, but only if the user chose to investigate that option.
 
-<img src="/image_samples/medavie/delisted-providers/search-delisted-only.jpg" style="margin: auto; width: 70%; padding-bottom:10px;">
+<img src="/image_samples/medavie/delisted-providers/search-delisted-only.jpg" alt="Search results showing only delisted providers" style="margin: auto; width: 70%; padding-bottom:10px;">
 
 Since the delisted filter and search results are hidden by default, the previous experience would not work for scenario 3. We didn't want to bring the user to an empty search results page. Normally, when a search returns no results, an alert bottom sheet appears requesting the user try again. We repurposed this alert to let them know their search didn't match any active providers, and encourage them to search for something else.
 
-<img src="/image_samples/medavie/delisted-providers/description.png" style="margin: auto; width: 100%; padding-bottom:10px;">
+<img src="/image_samples/medavie/delisted-providers/description.png" alt="Expanded filter explaining delisted providers" style="margin: auto; width: 100%; padding-bottom:10px;">
 
 In search results and in the user's list of saved providers, delisted providers would be labeled clearly. On individual provider pages, a prominent alert would appear with a brief explanation that the provider is delisted.
 
-<img src="/image_samples/medavie/delisted-providers/final-flow.jpg" style="margin: auto; width: 100%; padding-bottom:10px;">
+<img src="/image_samples/medavie/delisted-providers/final-flow.jpg" alt="Final flow for delisted provider search" style="margin: auto; width: 100%; padding-bottom:10px;">
 
 We presented our solution to the stakeholders, and it was accepted. 

--- a/ebmorran.github.io/content/medavie-blue-cross/microcopy.md
+++ b/ebmorran.github.io/content/medavie-blue-cross/microcopy.md
@@ -13,12 +13,12 @@ toc: false
 ## Claiming requirements
 On the details page for every covered benefit, our member site displays a list of requirements for claiming that benefit. I was asked to rewrite some of these claiming requirements to make them more reader-friendly.
 
-<img src="/image_samples/medavie/claiming-requirements.png" style="width:80%; padding-bottom: 20px;">
+<img src="/image_samples/medavie/claiming-requirements.png" alt="Screenshot of revised claiming requirements" style="width:80%; padding-bottom: 20px;">
 
 ## Pharmacy statement modal
 Our claims history page doesn't include claim statements for claims directly billed by the pharmacy. We needed an info alert to briefly explain this when clicked. 
 
-<img src="/image_samples/medavie/pharmacy-statement.png" style="width:80%; padding-bottom: 20px;">
+<img src="/image_samples/medavie/pharmacy-statement.png" alt="Info alert explaining pharmacy statements" style="width:80%; padding-bottom: 20px;">
 
 <!--## Conditional copay explanation-->
 <!--Conditional Copay is a version of step therapy we use to offer decreased medication copays to members who have already tried less costly equivalent options. I was asked to rewrite the explanation of Conditional Copay in our drug search. The "Conditional Copay" label appears even if the member's plan does not offer it, so the explanation needed to be framed in hypothetical terms: "if your plan uses Conditional Copay."-->

--- a/ebmorran.github.io/content/orchard/abandoned-cart.md
+++ b/ebmorran.github.io/content/orchard/abandoned-cart.md
@@ -18,16 +18,16 @@ toc: false
 
 ## Email 1
 
-<a href="/image_samples/orchard/abandoned-cart-1.png"><img src="/images/abandoned-cart-1-thumbnail.png" width="200"><br>
+<a href="/image_samples/orchard/abandoned-cart-1.png"><img src="/images/abandoned-cart-1-thumbnail.png" alt="Thumbnail of first abandoned cart email" width="200"><br>
 (Click to expand.)</a>
 
 
 ## Email 2
 
-<a href="/image_samples/orchard/abandoned-cart-2.png"><img src="/images/abandoned-cart-2-thumbnail.png" width="200"><br>
+<a href="/image_samples/orchard/abandoned-cart-2.png"><img src="/images/abandoned-cart-2-thumbnail.png" alt="Thumbnail of second abandoned cart email" width="200"><br>
 (Click to expand.)</a>
 
 ## Email 3
 
-<a href="/image_samples/orchard/abandoned-cart-3.png"><img src="/images/abandoned-cart-3-thumbnail.png" width="200"><br>
+<a href="/image_samples/orchard/abandoned-cart-3.png"><img src="/images/abandoned-cart-3-thumbnail.png" alt="Thumbnail of third abandoned cart email" width="200"><br>
 (Click to expand.)</a>

--- a/ebmorran.github.io/layouts/partials/sections/achievements.html
+++ b/ebmorran.github.io/layouts/partials/sections/achievements.html
@@ -10,7 +10,7 @@
                     <a class="card my-3 h-100 p-3" href="{{ .url }}" title="{{ .title }}" target="_blank">
                         {{if .image }}
                             <div class="card-head"><br>
-                                <img class="card-img-top" src="{{ .image }}">
+                                <img class="card-img-top" src="{{ .image }}" alt="{{ .title }}">
                             </div>
                         {{ end }}<!--
                         <div class="card-body bg-transparent">
@@ -26,7 +26,7 @@
                     <div class="card my-3 h-100 p-3" title="{{ .title }}">
                         {{if .image }}
                             <div class="card-head">
-                                <img class="card-img-top" src="{{ .image }}">
+                                <img class="card-img-top" src="{{ .image }}" alt="{{ .title }}">
                             </div>
                         {{ end }}<!--
                         <div class="card-body bg-transparent">

--- a/ebmorran.github.io/layouts/partials/sections/header.html
+++ b/ebmorran.github.io/layouts/partials/sections/header.html
@@ -53,7 +53,7 @@
             <a class="navbar-brand primary-font text-wrap" href="{{ .Site.BaseURL | relURL }}">
                 {{ if and (or (.Site.Params.favicon) (.Site.Params.navbar.brandLogo)) .Site.Params.navbar.showBrandLogo | default true }}
                 <img src="{{ .Site.Params.navbar.brandLogo | default .Site.Params.favicon }}" width="30" height="30"
-                    class="d-inline-block align-top">
+                    class="d-inline-block align-top" alt="{{ .Site.Params.navbar.brandName | default .Site.Params.title }}">
                 {{ .Site.Params.navbar.brandName | default .Site.Params.title }}
                 {{ else }}
                 {{ .Site.Params.navbar.brandName | default .Site.Params.title }}

--- a/ebmorran.github.io/static/html_samples/abandoned-cart-1.html
+++ b/ebmorran.github.io/static/html_samples/abandoned-cart-1.html
@@ -325,7 +325,7 @@
                                 <tr>
                                     <td align="left" valign="bottom" style="text-align:left;vertical-align:bottom;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                                       <div>
-                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
+                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="Orchard wordmark logo" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
                                         </div>
                                     </td>
                                 </tr>
@@ -394,7 +394,7 @@
               <table border="0" cellpadding="0" cellspacing="0" align="center" bgcolor="#ffffff" class="deviceWidth" style="width:580px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                      <img src="https://d1pgqke3goo8l6.cloudfront.net/x0uoiNnlSaanaw32WR2o_Untitled%20design%20(5).png" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1pgqke3goo8l6.cloudfront.net/x0uoiNnlSaanaw32WR2o_Untitled%20design%20(5).png" width="580" alt="Promotional banner with Orchard phone" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                   </td>
                 </tr>
               </table>
@@ -453,7 +453,7 @@
                           <table border="0" cellspacing="0" cellpadding="0" align="left" class="deviceWidth" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
                               <td align="left" valign="top" class="removePaddingForMobile" style="padding-top:0;padding-bottom:15px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                                <img src="https://d1pgqke3goo8l6.cloudfront.net/BMZ0QxHbQxikLQRPy8Pw_s-l400.jpg" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                                <img src="https://d1pgqke3goo8l6.cloudfront.net/BMZ0QxHbQxikLQRPy8Pw_s-l400.jpg" alt="Photo of a smartphone with Orchard branding" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -515,7 +515,7 @@
                           <!-- Start: Right hand column (image) -->
                           <table border="0" cellspacing="0" cellpadding="0" align="right" dir="rtl" class="deviceWidth" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
-                              <td align="left" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:15px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;"><img src="https://d1pgqke3goo8l6.cloudfront.net/IOivBUOTuCkhLqiD7pEl_Add%20a%20heading.png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+<td align="left" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:15px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;"><img src="https://d1pgqke3goo8l6.cloudfront.net/IOivBUOTuCkhLqiD7pEl_Add%20a%20heading.png" alt="Placeholder graphic labeled 'Add a heading'" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -614,7 +614,7 @@
           <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width:600px;">
             <tr>
               <td align="center" valign="top" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding: 0 0 5px 0;">
-                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard Wordmark Reversed SML.png' width="130" height="24.5" />
+                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard wordmark logo' width="130" height="24.5" />
               </td>
             </tr>
             <tr>

--- a/ebmorran.github.io/static/html_samples/abandoned-cart-2.html
+++ b/ebmorran.github.io/static/html_samples/abandoned-cart-2.html
@@ -346,7 +346,7 @@
                                 <tr>
                                     <td align="left" valign="bottom" style="text-align:left;vertical-align:bottom;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                                       <div>
-                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
+                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="Orchard wordmark logo" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
                                         </div>
                                     </td>
                                 </tr>
@@ -456,7 +456,7 @@
               <table id="pinkrow2" border="0" cellpadding="0" cellspacing="0" align="center" bgcolor="#ddb2ba" class="deviceWidth" style="width:580px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;border-left-width:1px;border-left-style:solid;border-left-color:#e2e3e7;border-right-width:1px;border-right-style:solid;border-right-color:#e2e3e7;background-color:#ddb2ba;">
                 <tr>
                   <td valign="top" align="center" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                      <img src="https://d1pgqke3goo8l6.cloudfront.net/fHzNLwvDSieJs4e7BHrY_looking-at-phone.png" align="center" width="180" alt="" border="0" class="deviceWidth" style="display:block;-ms-interpolation-mode:bicubic; margin:auto;" />
+                      <img src="https://d1pgqke3goo8l6.cloudfront.net/fHzNLwvDSieJs4e7BHrY_looking-at-phone.png" align="center" width="180" alt="Illustration of person looking at phone" border="0" class="deviceWidth" style="display:block;-ms-interpolation-mode:bicubic; margin:auto;" />
                   </td>
                 </tr>
               </table>
@@ -515,7 +515,7 @@
                           <!-- Start: Right hand column (image) -->
                           <table border="0" cellspacing="0" cellpadding="0" align="right" dir="rtl" class="hideForMobile" style="width:240px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
-                              <td align="right" valign="top" dir="ltr" class="deviceWidth" style="padding-top:50px;padding-bottom:0px;padding-right:20px;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/V9dM88wPTpKoyhvF6FLC_hands-phone-upright.png" alt="" border="0" class="deviceWidth" style="display:block;width:240px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                              <td align="right" valign="top" dir="ltr" class="deviceWidth" style="padding-top:50px;padding-bottom:0px;padding-right:20px;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/V9dM88wPTpKoyhvF6FLC_hands-phone-upright.png" alt="Hands holding phone upright" border="0" class="deviceWidth" style="display:block;width:240px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table> 
@@ -543,7 +543,7 @@
                           <table id="cbc-image-table" class="removePaddingForMobile" border="0" cellspacing="0" cellpadding="0" align="left" class="deviceWidth" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
                               <td valign="top" class="removePaddingForMobile" style="padding-top:0;padding-bottom:15px;padding-right:0;padding-left:30px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                                <img id="cbc-image" src="https://d1pgqke3goo8l6.cloudfront.net/KAZxgfTAGFpQ9M4uWAXi_cbc-adjusted.png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                                <img id="cbc-image" src="https://d1pgqke3goo8l6.cloudfront.net/KAZxgfTAGFpQ9M4uWAXi_cbc-adjusted.png" alt="CBC logo" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -605,7 +605,7 @@
                           <!-- Start: Right hand column (image) -->
                           <table border="0" cellspacing="0" cellpadding="0" align="right" dir="rtl" class="hideForMobile" style="width:240px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
-                              <td align="left" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:0px;padding-right:10px;padding-left:0px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;"><img src="https://d1pgqke3goo8l6.cloudfront.net/IDUE4eVtRXGP3Zvym8li_woman-jumping-shadow.png" alt="" class="deviceWidth" style="display:block;width:240px;-ms-interpolation-mode:bicubic;" />
+                              <td align="left" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:0px;padding-right:10px;padding-left:0px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;"><img src="https://d1pgqke3goo8l6.cloudfront.net/IDUE4eVtRXGP3Zvym8li_woman-jumping-shadow.png" alt="Woman jumping with shadow" class="deviceWidth" style="display:block;width:240px;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -827,7 +827,7 @@
           <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width:600px;">
             <tr>
               <td align="center" valign="top" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding: 0 0 5px 0;">
-                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard Wordmark Reversed SML.png' width="130" height="24.5" />
+                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard wordmark logo' width="130" height="24.5" />
               </td>
             </tr>
             <tr>

--- a/ebmorran.github.io/static/html_samples/abandoned-cart-3.html
+++ b/ebmorran.github.io/static/html_samples/abandoned-cart-3.html
@@ -326,7 +326,7 @@
                                 <tr>
                                     <td align="left" valign="bottom" style="text-align:left;vertical-align:bottom;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                                       <div>
-                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
+                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="Orchard wordmark logo" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
                                         </div>
                                     </td>
                                 </tr>
@@ -392,7 +392,7 @@
               <table border="0" cellpadding="0" cellspacing="0" align="center" bgcolor="#ffffff" class="deviceWidth" style="width:580px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;border-left-width:1px;border-left-style:solid;border-left-color:#e2e3e7; border-top-width:1px;border-top-style:solid;border-top-color:#e2e3e7;border-right-width:1px;border-right-style:solid;border-right-color:#e2e3e7;">
                 <tr>
                   <td valign="top" bgcolor="#6AA2B8" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                      <img src="https://d1pgqke3goo8l6.cloudfront.net/F4rEITg6SyyflzVMXQIj_hands-reaching-white-text%20(1).png" alt="" border="0" class="deviceWidth" style="width:578px; display:block;border-width:0;-ms-interpolation-mode:bicubic; margin:auto;" />
+                      <img src="https://d1pgqke3goo8l6.cloudfront.net/F4rEITg6SyyflzVMXQIj_hands-reaching-white-text%20(1).png" alt="Hands reaching toward Orchard phone" border="0" class="deviceWidth" style="width:578px; display:block;border-width:0;-ms-interpolation-mode:bicubic; margin:auto;" />
                   </td>
                 </tr>
               </table>
@@ -469,7 +469,7 @@ Orchard is here to help you get the greatest technology at the greatest price. G
                           <!-- Start: Right hand column (image) -->
                           <table border="0" cellspacing="0" cellpadding="0" align="right" dir="rtl" class="hideForMobile" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
-                              <td align="right" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:0px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/Biem2LFcS86FLj85JzF9_hands-phone%20(1).png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                              <td align="right" valign="top" dir="ltr" class="hideForMobile" style="padding-top:0;padding-bottom:0px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/Biem2LFcS86FLj85JzF9_hands-phone%20(1).png" alt="Hands holding phone" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table> 
@@ -497,7 +497,7 @@ Orchard is here to help you get the greatest technology at the greatest price. G
                           <table class="hideForMobile" border="0" cellspacing="0" cellpadding="0" align="left" class="deviceWidth" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
                               <td align="left" valign="bottom" class="removePaddingForMobile" style="padding-top:20px;padding-bottom:0px;padding-right:0;padding-left:10px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                                <img src="https://d1pgqke3goo8l6.cloudfront.net/52f2pNVS7i9NrKqOwbbh_man-sunglasses-phone%20(1).png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                                <img src="https://d1pgqke3goo8l6.cloudfront.net/52f2pNVS7i9NrKqOwbbh_man-sunglasses-phone%20(1).png" alt="Man in sunglasses holding phone" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -602,7 +602,7 @@ Orchard is here to help you get the greatest technology at the greatest price. G
                           <!-- Start: Right hand column (image) -->
                           <table border="0" cellspacing="0" cellpadding="0" align="right" dir="rtl" class="hideForMobile" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
-                              <td align="right" valign="top" dir="ltr" class="hideForMobile" style="padding-top:10px;padding-bottom:0px;padding-right:20px;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/GnTTxXbThKBZ3wj3iVck_woman-in-yellow-flipped.png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                              <td align="right" valign="top" dir="ltr" class="hideForMobile" style="padding-top:10px;padding-bottom:0px;padding-right:20px;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;text-align:right;"><img src="https://d1pgqke3goo8l6.cloudfront.net/GnTTxXbThKBZ3wj3iVck_woman-in-yellow-flipped.png" alt="Woman in yellow jumping" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table> 
@@ -629,7 +629,7 @@ Orchard is here to help you get the greatest technology at the greatest price. G
                           <table class="hideForMobile" border="0" cellspacing="0" cellpadding="0" align="left" class="deviceWidth" style="width:220px;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                             <tr>
                               <td align="left" valign="bottom" class="hideForMobile" style="padding-top:40px;padding-bottom:0px;padding-right:0;padding-left:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
-                                <img src="https://d1pgqke3goo8l6.cloudfront.net/d6szb2tbQyqZcY0agLSl_phone-tree-photo%20(1).png" alt="" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
+                                <img src="https://d1pgqke3goo8l6.cloudfront.net/d6szb2tbQyqZcY0agLSl_phone-tree-photo%20(1).png" alt="Phone displaying tree photo" border="0" class="deviceWidth" style="display:block;width:220px;border-width:0;-ms-interpolation-mode:bicubic;" />
                               </td>
                             </tr>
                           </table>
@@ -741,7 +741,7 @@ Orchard is here to help you get the greatest technology at the greatest price. G
           <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width:600px;">
             <tr>
               <td align="center" valign="top" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding: 0 0 5px 0;">
-                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard Wordmark Reversed SML.png' width="130" height="24.5" />
+                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard wordmark logo' width="130" height="24.5" />
               </td>
             </tr>
             <tr>

--- a/ebmorran.github.io/static/html_samples/our-story.html
+++ b/ebmorran.github.io/static/html_samples/our-story.html
@@ -103,7 +103,7 @@
 <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:300px;" width="100%">
 <tbody><tr>
 <td align="left" class="mobile-center" style="font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-size: 36px; font-weight: 800; line-height: 22px;" valign="bottom">
-<span href="http://www.getorchard.com" style="color: #ffffff; text-decoration: none;" target="_blank"><img height="" src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" width="120"></span>
+<span href="http://www.getorchard.com" style="color: #ffffff; text-decoration: none;" target="_blank"><img height="" src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" width="120" alt="Orchard wordmark logo"></span>
 </td>
 </tr>
 </tbody></table>
@@ -267,7 +267,7 @@ See you soon!<br>
 <table align="center" border="0" cellpadding="0" cellspacing="0" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width:600px;" width="100%">
 <tbody><tr>
 <td align="center" class="mobile-hide" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding: 0 0 5px 0;" valign="top">
-<img alt="Orchard Wordmark Reversed SML.png" height="24.5" src="https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png" width="130">
+<img alt="Orchard wordmark logo" height="24.5" src="https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png" width="130">
 </td>
 </tr>
 <tr>

--- a/ebmorran.github.io/static/html_samples/pixel2.html
+++ b/ebmorran.github.io/static/html_samples/pixel2.html
@@ -327,7 +327,7 @@
                                 <tr>
                                     <td align="left" valign="bottom" style="text-align:left;vertical-align:bottom;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                                       <div>
-                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
+                                        <img src="https://d1pgqke3goo8l6.cloudfront.net/oXUDtzzCQ0SkFrZuWRK0_Orchard%20Wordmark%20549%20SML.png" height="30" align="center" alt="Orchard wordmark logo" border="0" class="logoForMobile" style="display:block; margin:  auto; border-width:0;-ms-interpolation-mode:bicubic;" />
                                         </div>
                                     </td>
                                 </tr>
@@ -397,7 +397,7 @@
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                     <span "3689" href="https://www.getorchard.com/search/shop-for-featured-android-phones/">
-                      <img src="https://d1pgqke3goo8l6.cloudfront.net/pi0zw9UkRQ2m3Z8t6mHT_pixel-tinted.png" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1pgqke3goo8l6.cloudfront.net/pi0zw9UkRQ2m3Z8t6mHT_pixel-tinted.png" width="580" alt="Tinted Google Pixel phone" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                     </span>
                   </td>
                 </tr>
@@ -501,7 +501,7 @@
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                     <span "3915" href="https://www.getorchard.com/search/shop-for-featured-android-phones/">
-                      <img src="https://d1ergv6ync1qqr.cloudfront.net/G6eJroJBRlKnoJup28Gx_pixel%205.jpg" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1ergv6ync1qqr.cloudfront.net/G6eJroJBRlKnoJup28Gx_pixel%205.jpg" width="580" alt="Pixel 5 smartphone" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                     </span>
                   </td>
                 </tr>
@@ -563,7 +563,7 @@
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                     <span "1610" href="https://www.getorchard.com/search/shop-for-featured-android-phones/">
-                      <img src="https://d1ergv6ync1qqr.cloudfront.net/7522cLUvSqmHuDzDqqzo_pixel%204a.jpg" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1ergv6ync1qqr.cloudfront.net/7522cLUvSqmHuDzDqqzo_pixel%204a.jpg" width="580" alt="Pixel 4a smartphone" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                     </span>
                   </td>
                 </tr>
@@ -625,7 +625,7 @@
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                     <span "8968" href="https://www.getorchard.com/search/shop-for-featured-android-phones/">
-                      <img src="https://d1ergv6ync1qqr.cloudfront.net/ngc9GMibTgWE1TJYowiz_pixel-3a.png" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1ergv6ync1qqr.cloudfront.net/ngc9GMibTgWE1TJYowiz_pixel-3a.png" width="580" alt="Pixel 3a smartphone" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                     </span>
                   </td>
                 </tr>
@@ -686,7 +686,7 @@
                 <tr>
                   <td valign="top" bgcolor="#ffffff" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0;">
                     <span "6646" href="https://www.getorchard.com/search/shop-for-featured-android-phones/">
-                      <img src="https://d1ergv6ync1qqr.cloudfront.net/xjuAckJ0SuioNze4I4gJ_android-slice.jpg" width="580" alt="" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
+                      <img src="https://d1ergv6ync1qqr.cloudfront.net/xjuAckJ0SuioNze4I4gJ_android-slice.jpg" width="580" alt="Android interface slice" border="0" class="deviceWidth" style="display:block;border-width:0;-ms-interpolation-mode:bicubic;" />
                     </span>
                   </td>
                 </tr>
@@ -824,7 +824,7 @@
           <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width:600px;">
             <tr>
               <td align="center" valign="top" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding: 0 0 5px 0;">
-                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard Wordmark Reversed SML.png' width="130" height="24.5" />
+                <img src='https://d1pgqke3goo8l6.cloudfront.net/Ldvbg6J0S6CLogLOYxul_Orchard%20Wordmark%20549%20MED.png' alt='Orchard wordmark logo' width="130" height="24.5" />
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- provide descriptive alt text for images across posts and templates
- ensure navigation and email samples reference brand and illustrations accessibly

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68ab671bb1dc83309ab9a2b54df5c5ec