### PR TITLE
Ensure table images remain at full opacity

### DIFF
--- a/ebmorran.github.io/static/css/single.css
+++ b/ebmorran.github.io/static/css/single.css
@@ -102,6 +102,10 @@
     opacity: 0.9;
 }
 
+#single .page-content table img {
+    opacity: 1 !important;
+}
+
 #single .page-content table > thead > tr {
     background-color: var(--secondary-color) !important;
     color: var(--secondary-color) !important;


### PR DESCRIPTION
## Summary
- Override table-level opacity so images inside tables display at full brightness

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2082550708330a3121b45a40c65e5