### PR TITLE
Remove table opacity so images render at full brightness

### DIFF
--- a/ebmorran.github.io/static/css/single.css
+++ b/ebmorran.github.io/static/css/single.css
@@ -81,7 +81,6 @@
     max-width: 100%;
     display: block;
     overflow-x: auto;
-    opacity: 0.8;
 }
 
 #single .page-content table > tr {
@@ -93,13 +92,15 @@
     background-color: var(--primary-color) !important;
     color: var(--secondary-color) !important;
     border: 1px solid var(--secondary-color);
-    opacity: 0.9;
 }
 #single .page-content table > tbody > tr > td {
     padding: 0.5rem !important;
     border: 1px solid var(--secondary-color);
     background-color: var(--secondary-color) !important;
-    opacity: 0.9;
+}
+
+#single .page-content table img {
+    opacity: 1 !important;
 }
 
 #single .page-content table > thead > tr {


### PR DESCRIPTION
## Summary
- Remove opacity styles from tables, headers, and cells so nested content isn't dimmed
- Retain explicit `table img` rule to guarantee images stay fully opaque

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2082550708330a3121b45a40c65e5