### PR TITLE
Fix table image alignment within rows

### DIFF
--- a/ebmorran.github.io/static/css/single.css
+++ b/ebmorran.github.io/static/css/single.css
@@ -100,10 +100,13 @@
     border: 1px solid var(--secondary-color);
     background-color: var(--secondary-color) !important;
     opacity: 0.9;
+    line-height: 0;
+    vertical-align: bottom;
 }
 
 #single .page-content table img {
     opacity: 1 !important;
+    display: block;
 }
 
 #single .page-content table > thead > tr {


### PR DESCRIPTION
## Summary
- remove inline spacing in table cells so images align with row height
- render table images as block elements

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68b223e4017c8330b4f91dbf8c1888b4